### PR TITLE
added support to bme280 for humidity. code based on bosch driver

### DIFF
--- a/src/mgos_barometer_bme280.c
+++ b/src/mgos_barometer_bme280.c
@@ -17,10 +17,12 @@
 #include "mgos_barometer_bme280.h"
 #include "mgos_i2c.h"
 
+#define BME280_CONCAT_BYTES(msb, lsb)            (((uint16_t)msb << 8) | (uint16_t)lsb)
+
 // Datasheet:
 // https://cdn-shop.adafruit.com/datasheets/BST-BME280_DS001-10.pdf
 //
-// TODO(pim): Add humidity sensing
+
 
 bool mgos_barometer_bme280_detect(struct mgos_barometer *dev) {
   int val;
@@ -32,6 +34,9 @@ bool mgos_barometer_bme280_detect(struct mgos_barometer *dev) {
   if ((val = mgos_i2c_read_reg_b(dev->i2c, dev->i2caddr, BME280_REG_DEVID)) < 0) {
     return false;
   }
+
+  LOG(LL_DEBUG, ("Detecting BMx280 %d, reg b is: %d", dev->i2caddr, val));
+
 
   if (val == 0x56 || val == 0x57) {
     LOG(LL_INFO, ("Preproduction version of BMP280 detected (0x%02x)", val));
@@ -74,6 +79,29 @@ bool mgos_barometer_bme280_create(struct mgos_barometer *dev) {
     return false;
   }
 
+  if( dev->capabilities && MGOS_BAROMETER_CAP_HYGROMETER ) {
+    uint8_t reg_data[ 7 ];
+    int16_t dig_h4_lsb;
+    int16_t dig_h4_msb;
+    int16_t dig_h5_lsb;
+    int16_t dig_h5_msb;
+
+    if (!mgos_i2c_read_reg_n(dev->i2c, dev->i2caddr, BME280_REG_HUMIDITY_CALIB_ADDR, 7, reg_data)) {
+      free(dev->user_data);
+      return false;
+    }
+
+    bme280_data->calib.dig_H2 = (int16_t)BME280_CONCAT_BYTES(reg_data[1], reg_data[0]);
+    bme280_data->calib.dig_H3 = reg_data[2];
+    dig_h4_msb = (int16_t)(int8_t)reg_data[3] * 16;
+    dig_h4_lsb = (int16_t)(reg_data[4] & 0x0F);
+    bme280_data->calib.dig_H4 = dig_h4_msb | dig_h4_lsb;
+    dig_h5_msb = (int16_t)(int8_t)reg_data[5] * 16;
+    dig_h5_lsb = (int16_t)(reg_data[4] >> 4);
+    bme280_data->calib.dig_H5 = dig_h5_msb | dig_h5_lsb;
+    bme280_data->calib.dig_H6 = (int8_t)reg_data[6];
+  }
+
   // SPI | 0.5ms period | 16X IIR filter
   if (!mgos_i2c_write_reg_b(dev->i2c, dev->i2caddr, BME280_REG_CONFIG, 0x00 | BME280_STANDBY_500us << 2 | BME280_FILTER_16X << 5)) {
     free(dev->user_data);
@@ -81,11 +109,20 @@ bool mgos_barometer_bme280_create(struct mgos_barometer *dev) {
   }
   mgos_usleep(10000);
 
+
+  // Humidity OS
+  if (!mgos_i2c_write_reg_b(dev->i2c, dev->i2caddr, BME280_REG_CTRL_HUM, BME280_OVERSAMP_2X)) {
+    free(dev->user_data);
+    return false;
+  }
+  mgos_usleep(5000);
+
   // Mode | Pressure OS | Temp OS
   if (!mgos_i2c_write_reg_b(dev->i2c, dev->i2caddr, BME280_REG_CTRL_MEAS, BME280_MODE_NORMAL | BME280_OVERSAMP_16X << 2 | BME280_OVERSAMP_2X << 5)) {
     free(dev->user_data);
     return false;
   }
+
 
   dev->capabilities |= MGOS_BAROMETER_CAP_BAROMETER;
   dev->capabilities |= MGOS_BAROMETER_CAP_THERMOMETER;
@@ -116,17 +153,19 @@ bool mgos_barometer_bme280_read(struct mgos_barometer *dev) {
   }
 
   // read data from sensor
-  uint8_t data[6];
-  if (!mgos_i2c_read_reg_n(dev->i2c, dev->i2caddr, BME280_REG_PRESSURE_MSB, 6, data)) {
+  uint8_t data[8];
+  if (!mgos_i2c_read_reg_n(dev->i2c, dev->i2caddr, BME280_REG_PRESSURE_MSB, 8, data)) {
     return false;
   }
-  int32_t Padc, Tadc;
-  Padc = (int32_t)((((uint32_t)(data[0])) << 12) | (((uint32_t)(data[1])) << 4) | ((uint32_t)data[2] >> 4));
-  Tadc = (int32_t)((((uint32_t)(data[3])) << 12) | (((uint32_t)(data[4])) << 4) | ((uint32_t)data[5] >> 4));
-//  LOG(LL_DEBUG, ("Padc=%d Tadc=%d", Padc, Tadc));
+  uint32_t Padc, Tadc, Hadc;
+  Padc = (uint32_t)((((uint32_t)(data[0])) << 12) | (((uint32_t)(data[1])) << 4) | ((uint32_t)data[2] >> 4));
+  Tadc = (uint32_t)((((uint32_t)(data[3])) << 12) | (((uint32_t)(data[4])) << 4) | ((uint32_t)data[5] >> 4));
+  Hadc = (data[6]) << 8 | data[7];
 
   // Convert data (from datasheet, section 8.1)
-  double  var1, var2, T, P;
+  double  var1, var2, var3, var4, var5, var6, T, P, H;
+  double H_min = 1.0;
+  double H_max = 100.0;
   int32_t t_fine;
 
   // Compensation for temperature -- double precision
@@ -155,7 +194,27 @@ bool mgos_barometer_bme280_read(struct mgos_barometer *dev) {
   }
   dev->pressure = (float)P;
 
-//  LOG(LL_DEBUG, ("P=%.2f T=%.2f", dev->pressure, dev->temperature));
+  H = 0.0;
+  if( dev->capabilities && MGOS_BAROMETER_CAP_HYGROMETER ) {
+    // Compensation for humidity
+    var1 = ((double)t_fine) - 76800.0;
+    var2 = (((double)bme280_data->calib.dig_H4) * 64.0 + (((double) bme280_data->calib.dig_H5) / 16384.0) * var1);
+    var3 = Hadc - var2;
+    var4 = ((double)bme280_data->calib.dig_H2) / 65536.0;
+    var5 = (1.0 + (((double) bme280_data->calib.dig_H3) / 67108864.0) * var1);
+    var6 = 1.0 + (((double) bme280_data->calib.dig_H6) / 67108864.0) * var1 * var5;
+    var6 = var3 * var4 * (var5 * var6);
+    H = var6 * (1.0 - ((double) bme280_data->calib.dig_H1) * var6 / 524288.0);
+
+    if (H > H_max)
+        H = H_max;
+    else if (H < H_min)
+        H = H_min;
+  }
+
+  dev->humidity = (float)H;
+  
+  LOG(LL_DEBUG, ("P=%.2f T=%.2f H=%.2f", dev->pressure, dev->temperature, dev->humidity));
 
   return true;
 }

--- a/src/mgos_barometer_bme280.h
+++ b/src/mgos_barometer_bme280.h
@@ -22,6 +22,7 @@
 // DevID: 0x56/0x57 are samples of BMP280; 0x58 is mass production BMP280; 0x60 is BME280
 #define BME280_REG_DEVID                           (0xD0) /* Chip ID Register */
 #define BME280_REG_RESET                           (0xE0) /* Softreset Register */
+#define BME280_REG_CTRL_HUM                        (0xF2) /* Humidity oversampling */
 #define BME280_REG_STATUS                          (0xF3) /* Status Register */
 #define BME280_REG_CTRL_MEAS                       (0xF4) /* Ctrl Measure Register */
 #define BME280_REG_CONFIG                          (0xF5) /* Configuration Register */
@@ -38,6 +39,7 @@
 #define BME280_MODE_NORMAL                         (0x03)
 
 #define BME280_REG_TEMPERATURE_CALIB_DIG_T1_LSB    (0x88)
+#define BME280_REG_HUMIDITY_CALIB_ADDR             (0xE1)
 
 #define BME280_OVERSAMP_SKIPPED                    (0x00)
 #define BME280_OVERSAMP_1X                         (0x01)


### PR DESCRIPTION
Hi Pim and Sergey,
I have been using the homeassistant lib successfully on my sensor nodes. The thing I was missing was the humidity support for BME280 Bosch sensors and I added it by combing through the datasheet and the driver code coming from Bosch.
Hope this helps